### PR TITLE
(feat) nginx primary domain config

### DIFF
--- a/ansible/default.conf.njk
+++ b/ansible/default.conf.njk
@@ -14,7 +14,7 @@ server {
   }
 
   location / {
-    return 301 https://{{domain.hostname}}$request_uri;
+    return 301 https://{{primary_domainname}}$request_uri;
   }
 }
 {% endfor %}

--- a/ansible/default.ssl.conf.njk
+++ b/ansible/default.ssl.conf.njk
@@ -12,6 +12,25 @@ server {
   ssl_certificate /etc/nginx/ssl/live/{{domain.hostname}}/fullchain.pem;
   ssl_certificate_key /etc/nginx/ssl/live/{{domain.hostname}}/privkey.pem;
 
+  location = /exist/apps/tei-publisher/documentation {
+    return 301 https://{{primary_domainname}}/browse.html?collection=doc;
+  }
+  location = /exist/apps/tei-publisher/documentation/create-app {
+    return 301 https://{{primary_domainname}}/doc/quickstart.xml;
+  }
+  location = /exist/apps/tei-publisher/documentation/installation {
+    return 301 https://{{primary_domainname}}/doc/installation.xml;
+  }
+  location = /exist/apps/tei-publisher-home/index.html {
+    return 301 https://{{primary_domainname}}/index.html;
+  }
+
+{% if domain.hostname != primary_domainname %}
+  location / {
+    return 301 https://{{primary_domainname}}$request_uri;
+  }
+{% else %}
+
   location / {
     proxy_pass http://docker-publisher{{domain.root}}$request_uri;
     proxy_redirect http://$host{{domain.root}}/ /;
@@ -90,6 +109,8 @@ server {
   }
 {% endfor %}
 {% endif %}
+
+{% endif %}{# domain.hostname != primary_domainname #}
 
 {% if services.iiif %}
   location /iiif {

--- a/ansible/variables.yml
+++ b/ansible/variables.yml
@@ -6,6 +6,7 @@ services:
   iiif: true
   # Named entity recognition
   ner: true
+primary_domainname: tei-publisher.org
 # the domains to be served by the proxy. Each domain may map to a different app and root path
 # within the same eXist-db instance
 domains:


### PR DESCRIPTION
This sets a primary domain name `tei-publisher.org` for SEO improvements. All other other nginx hostnames (com/org, www or not, dash or now) shall return 301 permanent redirects to the primary domain name.

- add Ansible var `primary_domainname`
- all HTTP => HTTPS redirects go to the primary domain name, not to the individual hostnames (avoids double redirects)
- all custom redirects (because URL naming changed) go to the primary domain name
- all domains in the current template go to the primary domain name UNLESS domain.name is the primary domain name
- only the primary domain shall have the location parts defined
