### PR TITLE
fix: use admin_pass instead of admin.password

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -105,9 +105,9 @@
         - password
     - name: Set admin password
       ansible.builtin.shell:
-        cmd: docker compose exec publisher java org.exist.start.Main client -x 'sm:passwd("admin", "{{admin.password}}")'
+        cmd: docker compose exec publisher java org.exist.start.Main client -x 'sm:passwd("admin", "{{admin_pass}}")'
         chdir: "{{dest}}"
-      when: admin.password is defined and admin.password != ''
+      when: admin_pass is defined and admin_pass != ''
       tags:
         - password
     - name: Acquire certificates

--- a/ansible/update.yml
+++ b/ansible/update.yml
@@ -40,9 +40,9 @@
         - password
     - name: Set admin password
       ansible.builtin.shell:
-        cmd: docker compose exec publisher java org.exist.start.Main client -x 'sm:passwd("admin", "{{admin.password}}")'
+        cmd: docker compose exec publisher java org.exist.start.Main client -x 'sm:passwd("admin", "{{admin_passw}}")'
         chdir: "{{dest}}"
-      when: admin.password is defined and admin.password != ''
+      when: admin_pass is defined and admin_pass != ''
       tags:
         - password
     - import_tasks: check.yml


### PR DESCRIPTION
When using Ansible, it prompts for the eXist-db admin password and keeps that in var admin_pass. But the tasks that set the password use the undefined variable admin.password, so the prompted password is not applied.